### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,5 +7,7 @@
     "language": "python",
     "library_type": "CORE",
     "repo": "googleapis/python-api-common-protos",
-    "distribution_name": "googleapis-common-protos"
-  }
+    "distribution_name": "googleapis-common-protos",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
Both `default_version` and `codeowner_team` have empty strings for this repo. By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs:

https://github.com/googleapis/synthtool/pull/1201
https://github.com/googleapis/synthtool/pull/1114