### PR TITLE
chore: update release_level in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "googleapis-common-protos",
     "name_pretty": "Google APIs Common Protos",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/googleapis-common-protos/latest",
+    "client_documentation": "https://github.com/googleapis/python-api-common-protos",
     "issue_tracker": "https://github.com/googleapis/python-api-common-protos/issues",
     "release_level": "stable",
     "language": "python",

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,5 @@
     "repo": "googleapis/python-api-common-protos",
     "distribution_name": "googleapis-common-protos",
     "default_version": "",
-    "codeowner_team": "",
-    "api_shortname": "googleapis-common-protos"
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,14 @@
 {
     "name": "googleapis-common-protos",
     "name_pretty": "Google APIs Common Protos",
-    "client_documentation": "https://github.com/googleapis/python-api-common-protos",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/googleapis-common-protos/latest",
     "issue_tracker": "https://github.com/googleapis/python-api-common-protos/issues",
-    "release_level": "ga",
+    "release_level": "stable",
     "language": "python",
     "library_type": "CORE",
     "repo": "googleapis/python-api-common-protos",
     "distribution_name": "googleapis-common-protos",
     "default_version": "",
-    "codeowner_team": ""
+    "codeowner_team": "",
+    "api_shortname": "googleapis-common-protos"
 }


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 