### PR TITLE
fix: invalid `dev` version identifiers in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ description = "Common protobufs used in Google APIs"
 version = "1.59.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "protobuf>=3.19.5,<5.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 
-extras_require = {"grpc": ["grpcio >= 1.44.0, <2.0.0dev"]}
+extras_require = {"grpc": ["grpcio >= 1.44.0, <2.0.0.dev0"]}
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Not ~PEP 440~ distlib compliant.

Fixes #165