### PR TITLE
chore(revert): revert update grpc extra to require grpcio >= 1.51.3

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def default(session, repository=None):
     )
 
     # If there is no repository specific constraints path, use the default one.
-    if not constraints_path:
+    if not Path(constraints_path).exists():
         constraints_path = str(
             CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,9 +55,14 @@ def default(session, repository=None):
     session.install("mock==5.0.0", "pytest", "pytest-cov")
     session.install("-e", ".")
 
-    constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}-{repository}.txt"
-    )
+    if repository == "python-pubsub":
+        constraints_path = str(
+            CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}-{repository}.txt"
+        )
+    else:
+        constraints_path = str(
+            CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+        )
 
     # Install googleapis-api-common-protos
     # This *must* be the last install command to get the package from source.

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,11 +55,13 @@ def default(session, repository=None):
     session.install("mock==5.0.0", "pytest", "pytest-cov")
     session.install("-e", ".")
 
-    if repository == "python-pubsub":
-        constraints_path = str(
-            CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}-{repository}.txt"
-        )
-    else:
+    # Use the repository specific constraints path if it exists
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}-{repository}.txt"
+    )
+
+    # If there is no repository specific constraints path, use the default one.
+    if not constraints_path:
         constraints_path = str(
             CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -90,7 +90,7 @@ def unit(session, repository=None):
     default(session, repository)
 
 
-def system(session):
+def system(session, repository=None):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
@@ -114,9 +114,17 @@ def system(session):
 
     session.install("-e", ".")
 
+    # Use the repository specific constraints path if it exists
     constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}-{repository}.txt"
     )
+
+    # If there is no repository specific constraints path, use the default one.
+    if not Path(constraints_path).exists():
+        constraints_path = str(
+            CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+        )
+
 
     # Install googleapis-api-common-protos
     # This *must* be the last install command to get the package from source.
@@ -174,7 +182,7 @@ def test(session, library):
         if repository == "python-pubsub":
             session.install("psutil")
             session.install("flaky")
-        system(session)
+        system(session, repository)
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
 def tests_local(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def lint_setup_py(session):
     session.run("python", "setup.py", "check", "--strict")
 
 
-def default(session):
+def default(session, repository=None):
     # Install all test dependencies, then install this package in-place.
     session.install("asyncmock", "pytest-asyncio")
 
@@ -56,7 +56,7 @@ def default(session):
     session.install("-e", ".")
 
     constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}-{repository}.txt"
     )
 
     # Install googleapis-api-common-protos
@@ -78,9 +78,9 @@ def default(session):
     )
 
 
-def unit(session):
+def unit(session, repository=None):
     """Run the unit test suite."""
-    default(session)
+    default(session, repository)
 
 
 def system(session):
@@ -160,7 +160,7 @@ def test(session, library):
     if package:
         session.cd(f'packages/{package}')
 
-    unit(session)
+    unit(session, repository)
 
     # system tests are run on 3.7 only
     if session.python == "3.7":

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,7 @@ dependencies = [
     "protobuf>=3.19.5,<5.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 
-# Require grpcio >= 1.51.3 for compatibility with Mac M1
-# https://github.com/googleapis/python-pubsub/pull/900
-extras_require = {"grpc": ["grpcio >= 1.51.3, <2.0.0.dev0"]}
+extras_require = {"grpc": ["grpcio >= 1.44.0, <2.0.0.dev0"]}
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 

--- a/testing/constraints-3.7-python-pubsub.txt
+++ b/testing/constraints-3.7-python-pubsub.txt
@@ -1,0 +1,9 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+protobuf==3.19.5
+grpcio==1.51.3

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,4 +6,4 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 protobuf==3.19.5
-grpcio==1.51.3
+grpcio==1.44.0

--- a/testing/constraints-3.9-python-pubsub.txt
+++ b/testing/constraints-3.9-python-pubsub.txt
@@ -1,0 +1,9 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+protobuf==3.20.2
+grpcio==1.51.3

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -6,4 +6,4 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 protobuf==3.20.2
-grpcio==1.51.3
+grpcio==1.44.0


### PR DESCRIPTION
This PR reverts the change made in https://github.com/googleapis/python-api-common-protos/pull/190 to bump the minimum requirements of `grpc`. The change was made to match the PR in `python-pubsub` in https://github.com/googleapis/python-pubsub/pull/900. It would be better to emit deprecation warnings for users on older versions before changing the minimum requirements of this library.