### PR TITLE
chore: Release candidate v1.63.2rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.63.2](https://github.com/googleapis/python-api-common-protos/compare/v1.63.1...v1.63.2) (2024-06-19)
+
+
+### Bug Fixes
+
+* **deps:** Require protobuf&gt;=3.20.2 ([c77c0dc](https://github.com/googleapis/python-api-common-protos/commit/c77c0dc5d29ef780d781a3c5d757736a9ed09674))
+* Regenerate pb2 files for compatibility with protobuf 5.x ([c77c0dc](https://github.com/googleapis/python-api-common-protos/commit/c77c0dc5d29ef780d781a3c5d757736a9ed09674))
+
 ## [1.63.1](https://github.com/googleapis/python-api-common-protos/compare/v1.63.0...v1.63.1) (2024-05-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.63.2](https://github.com/googleapis/python-api-common-protos/compare/v1.63.1...v1.63.2) (2024-06-19)
+## [1.63.2rc0](https://github.com/googleapis/python-api-common-protos/compare/v1.63.1...v1.63.2rc0) (2024-06-19)
 
 
 ### Bug Fixes

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import find_namespace_packages
 
 name = "googleapis-common-protos"
 description = "Common protobufs used in Google APIs"
-version = "1.63.2"
+version = "1.63.2rc0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "protobuf>=3.20.2,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import find_namespace_packages
 
 name = "googleapis-common-protos"
 description = "Common protobufs used in Google APIs"
-version = "1.63.1"
+version = "1.63.2"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "protobuf>=3.20.2,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",


### PR DESCRIPTION
## [1.63.2rc0](https://github.com/googleapis/python-api-common-protos/compare/v1.63.1...v1.63.2rc0) (2024-06-19)


### Bug Fixes

* **deps:** Require protobuf&gt;=3.20.2 ([c77c0dc](https://github.com/googleapis/python-api-common-protos/commit/c77c0dc5d29ef780d781a3c5d757736a9ed09674))
* Regenerate pb2 files for compatibility with protobuf 5.x ([c77c0dc](https://github.com/googleapis/python-api-common-protos/commit/c77c0dc5d29ef780d781a3c5d757736a9ed09674))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).