### PR TITLE
build: fix presubmit

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -64,14 +64,14 @@ def unit(session, repository, package, prerelease, protobuf_implementation, work
     # Pin mock due to https://github.com/googleapis/python-pubsub/issues/840
     session.install("mock==5.0.0", "pytest", "pytest-cov")
 
+    session.install("-e", f"{working_dir}/{downstream_dir}")
+
     install_command = ["-e", f"{working_dir}/{downstream_dir}"]
     if prerelease:
         install_prerelease_dependencies(
             session,
             f"{working_dir}/{downstream_dir}/testing/constraints-{UNIT_TEST_PYTHON_VERSIONS[0]}.txt",
         )
-        # Use the `--no-deps` options to allow pre-release versions of dependencies to be installed
-        install_command.extend(["--no-deps"])
     else:
         contraints_file = f"{CURRENT_DIRECTORY}/testing/constraints-{session.python}-{repository}.txt"
         if not Path(contraints_file).exists():
@@ -79,9 +79,9 @@ def unit(session, repository, package, prerelease, protobuf_implementation, work
 
         install_command.extend(["-c", contraints_file])
 
-    # These *must* be the last 3 install commands to get the packages from source.
-    session.install(*install_command)
+        session.install(*install_command)
 
+    # These *must* be the last install commands to get the packages from source.
     # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
     # The 'cpp' implementation requires Protobuf<4.
     if protobuf_implementation == "cpp":

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,15 +64,14 @@ def unit(session, repository, package, prerelease, protobuf_implementation, work
     # Pin mock due to https://github.com/googleapis/python-pubsub/issues/840
     session.install("mock==5.0.0", "pytest", "pytest-cov")
 
-    session.install("-e", f"{working_dir}/{downstream_dir}")
-
-    install_command = ["-e", f"{working_dir}/{downstream_dir}"]
     if prerelease:
+        session.install("-e", f"{working_dir}/{downstream_dir}")
         install_prerelease_dependencies(
             session,
             f"{working_dir}/{downstream_dir}/testing/constraints-{UNIT_TEST_PYTHON_VERSIONS[0]}.txt",
         )
     else:
+        install_command = ["-e", f"{working_dir}/{downstream_dir}"]
         contraints_file = f"{CURRENT_DIRECTORY}/testing/constraints-{session.python}-{repository}.txt"
         if not Path(contraints_file).exists():
             contraints_file = f"{CURRENT_DIRECTORY}/testing/constraints-{session.python}.txt"

--- a/testing/constraints-3.7-python-pubsub.txt
+++ b/testing/constraints-3.7-python-pubsub.txt
@@ -7,5 +7,3 @@
 # Then this file should have foo==1.14.0
 protobuf==3.20.2
 grpcio==1.51.3
-opentelemetry-api
-opentelemetry-sdk

--- a/testing/constraints-3.7-python-pubsub.txt
+++ b/testing/constraints-3.7-python-pubsub.txt
@@ -7,3 +7,5 @@
 # Then this file should have foo==1.14.0
 protobuf==3.20.2
 grpcio==1.51.3
+opentelemetry-api
+opentelemetry-sdk


### PR DESCRIPTION
Fixes the error seen in https://github.com/googleapis/python-api-common-protos/pull/256 which occurred because opentelemetry was added as a direct dependency of `google-cloud-pubsub` and we run tests against pubsub via this code
https://github.com/googleapis/python-api-common-protos/blob/f30115b7302afc91bf06f210a270a6530b7fafdf/noxfile.py#L175-L176



```
==================================== ERRORS ====================================
____________________ ERROR collecting tests/unit/pubsub_v1 _____________________
/usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
:1381: in _gcd_import
    ???
:1354: in _find_and_load
    ???
:1325: in _find_and_load_unlocked
    ???
:929: in _load_unlocked
    ???
/tmpfs/src/github/python-api-common-protos/.nox/bd36180c/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:184: in exec_module
    exec(co, module.__dict__)
tests/unit/pubsub_v1/conftest.py:17: in 
    from opentelemetry.sdk.trace import TracerProvider
E   ModuleNotFoundError: No module named 'opentelemetry'
__________________ ERROR collecting tests/unit/test_pubsub.py __________________
ImportError while importing test module '/tmp/tmp765ev_kc/python-pubsub/tests/unit/test_pubsub.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/unit/test_pubsub.py:15: in 
    from google.cloud import pubsub
google/cloud/pubsub/__init__.py:20: in 
    from google.cloud.pubsub_v1 import PublisherClient
google/cloud/pubsub_v1/__init__.py:18: in 
    from google.cloud.pubsub_v1 import publisher
google/cloud/pubsub_v1/publisher/__init__.py:17: in 
    from google.cloud.pubsub_v1.publisher.client import Client
google/cloud/pubsub_v1/publisher/client.py:34: in 
    from google.cloud.pubsub_v1.publisher._batch import thread
google/cloud/pubsub_v1/publisher/_batch/thread.py:24: in 
    from opentelemetry import trace
E   ModuleNotFoundError: No module named 'opentelemetry'
```